### PR TITLE
Add link_colors URDFVisuals keyword argument.

### DIFF
--- a/src/MechanismGeometries.jl
+++ b/src/MechanismGeometries.jl
@@ -19,6 +19,9 @@ export AbstractGeometrySource,
        HyperPlane,
        URDFVisuals
 
+# Re-export from ColorTypes
+export RGBA
+
 abstract type AbstractGeometrySource end
 
 function visual_elements(mechanism, source::AbstractGeometrySource) end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,6 +166,23 @@ homog(t::Translation) = homog(AffineMap(Matrix(1.0I, 3, 3), t(SVector(0., 0., 0.
             robot = parse_urdf(Float64, urdf)
             elements = visual_elements(robot, URDFVisuals(urdf; tag="collision"))
         end
+
+        @testset "link_colors keyword argument" begin
+            urdf = "urdf/Acrobot.urdf"
+            robot = parse_urdf(Float64, urdf)
+            link = last(bodies(robot))
+            override_color = RGBA(0.1f0, 0.2f0, 0.3f0, 0.4f0)
+            link_colors = Dict(string(link) => override_color)
+            elements_override = visual_elements(robot, URDFVisuals(urdf; link_colors=link_colors))
+            elements_base = visual_elements(robot, URDFVisuals(urdf))
+            for (element_override, element_base) in zip(elements_override, elements_base)
+                if element_base == last(elements_base)
+                    @test element_override.color == override_color
+                else
+                    @test element_override.color == element_base.color
+                end
+            end
+        end
     end
 
     @testset "valkyrie" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ const rbd = RigidBodyDynamics
 using GeometryTypes
 using StaticArrays: SVector, SDiagonal
 using CoordinateTransformations: AffineMap, IdentityTransformation, LinearMap, Translation, transform_deriv
-using ColorTypes: RGBA
+using ColorTypes: RGBA, BGR
 using ValkyrieRobot
 using Compat
 using Compat.Test
@@ -171,15 +171,16 @@ homog(t::Translation) = homog(AffineMap(Matrix(1.0I, 3, 3), t(SVector(0., 0., 0.
             urdf = "urdf/Acrobot.urdf"
             robot = parse_urdf(Float64, urdf)
             link = last(bodies(robot))
-            override_color = RGBA(0.1f0, 0.2f0, 0.3f0, 0.4f0)
-            link_colors = Dict(string(link) => override_color)
-            elements_override = visual_elements(robot, URDFVisuals(urdf; link_colors=link_colors))
-            elements_base = visual_elements(robot, URDFVisuals(urdf))
-            for (element_override, element_base) in zip(elements_override, elements_base)
-                if element_base == last(elements_base)
-                    @test element_override.color == override_color
-                else
-                    @test element_override.color == element_base.color
+            for override_color in [RGBA(0.1f0, 0.2f0, 0.3f0, 0.4f0), BGR(0.1, 0.2, 0.3)]
+                link_colors = Dict(string(link) => override_color)
+                elements_override = visual_elements(robot, URDFVisuals(urdf; link_colors=link_colors))
+                elements_base = visual_elements(robot, URDFVisuals(urdf))
+                for (element_override, element_base) in zip(elements_override, elements_base)
+                    if element_base == last(elements_base)
+                        @test RGBA{Float32}(element_override.color) == RGBA{Float32}(override_color)
+                    else
+                        @test element_override.color == element_base.color
+                    end
                 end
             end
         end


### PR DESCRIPTION
Allows the user to override the material specified in the URDF without having to edit the URDF.

Also re-export RGBA from ColorTypes to make this easier to use.